### PR TITLE
adapt dockerfile for macos environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.6.1


### PR DESCRIPTION
When executing dockerfile in Macos I get this error
191.8   × Getting requirements to build wheel did not run successfully.
191.8   │ exit code: 255
191.8   ╰─> [1 lines of output]
191.8       Include folder should be at '/opt/java/openjdk/include' but doesn't exist. Please check you've installed the JDK properly.
191.8       [end of output]
 It is related to the version of openjdk. The fix update the image and set env for openjdk. I tested on Macos.